### PR TITLE
Fix to support IE8

### DIFF
--- a/regression.js
+++ b/regression.js
@@ -80,16 +80,16 @@ function fitData(data, typ) {
   var ypred = [];
 
   for (i = 0; i < data.length; i++) {
-	if (data[i] != null && Array.isArray(data[i])){
-		if (data[i] != null && data[i][0] != null && data[i][1] != null) {
-		  x.push(data[i][0]);
-		  y.push(data[i][1]);
-		}
-	}
-	else if(data[i] != null && typeof data[i] === 'number' ){//If type of X axis is category
-		x.push(i);
-		y.push(data[i]);
-	}
+    if (data[i] != null && Object.prototype.toString.call(data[i]) === '[object Array]') {
+      if (data[i] != null && data[i][0] != null && data[i][1] != null) {
+        x.push(data[i][0]);
+        y.push(data[i][1]);
+      }
+    }
+    else if(data[i] != null && typeof data[i] === 'number' ){//If type of X axis is category
+      x.push(i);
+      y.push(data[i]);
+    }
   }
 
   if (type == 'linear') {


### PR DESCRIPTION
_Problem:_
`Array.isArray` is not supported in IE8. (http://kangax.github.io/es5-compat-table/#Array.isArray)
This is the only thing that prevents this library from being used in IE8

_Solution:_
Replacing the use of that method with `Object.prototype.toString.call(arg) === "[object Array]";` as recommended by MDN (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Compatibility)

Also fixed incorrect indentation.
